### PR TITLE
Further work on Adams-Rbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@ FROM rocker/r-base:4.2.2
 
 USER root
 
+ENV REMOTES_VERSION 2.4.2
+ENV RENV_VERSION 0.17.3
+ENV BIOCMANAGER_VERSION 1.30.20
+ENV BIOCONDUCTOR_VERSION 3.16
+
+ENV RENV_CONFIG_CONNECT_TIMEOUT=120
+ENV RENV_CONFIG_CONNECT_RETRY=5
+RUN R -e "options('download.file.method'='curl', 'timeout'=120)"
+
 RUN apt-get update -y \
     && apt-get install --no-install-recommends -y \
        libssl-dev libxml2-dev libcurl4-openssl-dev libmagick++-dev libharfbuzz-dev \
@@ -15,16 +24,9 @@ RUN apt-get update -y \
 ENV OPT="/opt/rbase"
 ENV PATH="${OPT}/bin:$PATH"
 
-ENV RENV_VERSION 0.17.3
-ENV BIOCMANAGER_VERSION 1.30.20
-ENV BIOCONDUCTOR_VERSION 3.16
-
-RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/remotes/remotes_2.4.2.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/remotes/remotes_${REMOTES_VERSION}.tar.gz', repos=NULL, type='source')"
 RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
 RUN R -e "remotes::install_version(package = 'BiocManager', version = '${BIOCMANAGER_VERSION}')"
-
-ENV RENV_CONFIG_CONNECT_TIMEOUT=120
-ENV RENV_CONFIG_CONNECT_RETRY=5
 
 ENV RENV_PATHS_ROOT="${OPT}"
 WORKDIR "${OPT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN R -e "remotes::install_version(package = 'BiocManager', version = '${BIOCMAN
 
 ENV RENV_CONFIG_CONNECT_TIMEOUT=120
 ENV RENV_CONFIG_CONNECT_RETRY=5
+
 ENV RENV_PATHS_ROOT="${OPT}"
 WORKDIR "${OPT}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.
 RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
 RUN R -e "remotes::install_version(package = 'BiocManager', version = '${BIOCMANAGER_VERSION}')"
 
+ENV RENV_CONFIG_CONNECT_TIMEOUT=120
+ENV RENV_CONFIG_CONNECT_RETRY=5
 ENV RENV_PATHS_ROOT="${OPT}"
 WORKDIR "${OPT}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV RENV_VERSION 0.17.3
 ENV BIOCMANAGER_VERSION 1.30.20
 ENV BIOCONDUCTOR_VERSION 3.16
 
-RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org'))"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/remotes/remotes_2.4.2.tar.gz', repos=NULL, type='source')"
 RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
 RUN R -e "remotes::install_version(package = 'BiocManager', version = '${BIOCMANAGER_VERSION}')"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,18 @@ ENV OPT="/opt/rbase"
 ENV PATH="${OPT}/bin:$PATH"
 
 ENV RENV_VERSION 0.17.3
+ENV BIOCMANAGER_VERSION 1.30.20
+ENV BIOCONDUCTOR_VERSION 3.16
+
 RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org'))"
 RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
+RUN R -e "remotes::install_version(package = 'BiocManager', version = '${BIOCMANAGER_VERSION}')"
 
 ENV RENV_PATHS_ROOT="${OPT}"
 WORKDIR "${OPT}"
 
 COPY renv.lock renv.lock
-RUN R -e "renv::init(bioconductor = '3.16', force = TRUE, settings = list(use.cache = TRUE))"
+RUN R -e "renv::init(bioconductor = '${BIOCONDUCTOR_VERSION}', force = TRUE, settings = list(use.cache = TRUE), bare = TRUE, restart = TRUE)"
 RUN R -e "renv::restore()"
 
 RUN useradd rbase --shell /bin/bash --create-home --home-dir /home/rbase

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ renv::restore()
 ```
 
 You will need to agree to to the activation of the environment and loading of the packages (by typing "y").
-This will load the packages from the cache.
+This will load the packages from the cache. Restarting R maybe needed by entering `q()`, saving the workspace image `y` and starting R `R`.
 
 ### Singularity
 
@@ -75,7 +75,7 @@ renv::restore()
 ```
 
 You will need to agree to to the activation of the environment and loading of the packages (by typing "y").
-This will load the packages from the cache.
+This will load the packages from the cache. Restarting R maybe needed by entering `q()`, saving the workspace image `y` and starting R `R`.
 
 ### Extending the images
 

--- a/renv.lock
+++ b/renv.lock
@@ -191,7 +191,7 @@
     },
     "BiocManager": {
       "Package": "BiocManager",
-      "Version": "1.30.21",
+      "Version": "1.30.20",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [


### PR DESCRIPTION
Implemented the BiocManager fix
Tweaked the installation of the remotes package to specify the version of that package
Added some mitigation for the package download issues
- set the default download method to curl
- renv settings of connect timeout and retries increased to 120 (secs) and 5, respectively
- set the R options timeout to 120 (secs) 